### PR TITLE
Reutilizando logica de acceso a Camara

### DIFF
--- a/app/src/main/java/ar/utn/frba/mobile/plantis/CameraHandler.kt
+++ b/app/src/main/java/ar/utn/frba/mobile/plantis/CameraHandler.kt
@@ -1,0 +1,29 @@
+package ar.utn.frba.mobile.plantis
+
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Bitmap
+import android.provider.MediaStore
+import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import androidx.activity.result.*
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
+
+class CameraHandler (
+    image: ImageView, nextButton: Button,
+    registerForActivityResult: (contract: StartActivityForResult, callback: ActivityResultCallback<ActivityResult>) -> ActivityResultLauncher<Intent>
+) {
+    private val resultLauncher = registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val imageBitmap = result.data?.extras?.get("data") as Bitmap
+            image.setImageBitmap(imageBitmap)
+            nextButton.visibility = View.VISIBLE
+        }
+    }
+
+    fun launchTakePictureIntent() {
+        val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        resultLauncher.launch(cameraIntent)
+    }
+}

--- a/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/DrPlantisFragment.kt
+++ b/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/DrPlantisFragment.kt
@@ -1,53 +1,31 @@
 package ar.utn.frba.mobile.plantis.fragments
 
-import android.app.Activity
-import android.content.Intent
-import android.graphics.Bitmap
 import android.os.Bundle
-import android.provider.MediaStore
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import ar.utn.frba.mobile.plantis.CameraHandler
 import ar.utn.frba.mobile.plantis.R
 import ar.utn.frba.mobile.plantis.databinding.FragmentDrPlantisBinding
-import ar.utn.frba.mobile.plantis.databinding.FragmentSearchBinding
 
 class DrPlantisFragment : Fragment() {
-
     lateinit var binding: FragmentDrPlantisBinding
-    val REQUEST_IMAGE_CAPTURE = 1888
-
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentDrPlantisBinding.inflate(inflater, container, false)
-        binding.drplantisSearchButton.setOnClickListener{
-            dispatchTakePictureIntent()
-        }
         return binding.root
     }
 
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.drplantisNextButton.setOnClickListener { //TODO
-           val action = R.id.action_drPlantisFragment_to_drPlantisSearchResultsFragment
-           findNavController().navigate(action)
-        }
-    }
+        val cameraHandler = CameraHandler(binding.drplantisSearchImageView, binding.drplantisNextButton, ::registerForActivityResult)
 
-
-    @Suppress("DEPRECATION")
-    private fun dispatchTakePictureIntent() {
-        val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        startActivityForResult(cameraIntent, REQUEST_IMAGE_CAPTURE)
-    }
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == REQUEST_IMAGE_CAPTURE && resultCode == Activity.RESULT_OK) {
-            val imageBitmap = data?.extras?.get("data") as Bitmap
-            binding.drplantisSearchImageView.setImageBitmap(imageBitmap)
-            binding.drplantisNextButton.setVisibility(View.VISIBLE)
+        binding.drplantisSearchButton.setOnClickListener { cameraHandler.launchTakePictureIntent() }
+        binding.drplantisNextButton.setOnClickListener {
+            val action = R.id.action_fragment_search_to_fragment_search_results
+            findNavController().navigate(action)
         }
     }
 }

--- a/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/SearchFragment.kt
+++ b/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/SearchFragment.kt
@@ -1,53 +1,31 @@
 package ar.utn.frba.mobile.plantis.fragments
 
-import android.app.Activity.RESULT_OK
-import android.content.Intent
-import android.graphics.Bitmap
 import android.os.Bundle
-import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
-import android.widget.ImageView
 import androidx.fragment.app.Fragment
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
+import ar.utn.frba.mobile.plantis.CameraHandler
 import ar.utn.frba.mobile.plantis.R
 import ar.utn.frba.mobile.plantis.databinding.FragmentSearchBinding
 
-
 class SearchFragment : Fragment() {
     lateinit var binding: FragmentSearchBinding
-    val REQUEST_IMAGE_CAPTURE = 1888
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentSearchBinding.inflate(inflater, container, false)
-        binding.searchButton.setOnClickListener{
-            dispatchTakePictureIntent()
-        }
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val cameraHandler = CameraHandler(binding.searchImageView, binding.nextButton, ::registerForActivityResult)
+
+        binding.searchButton.setOnClickListener { cameraHandler.launchTakePictureIntent() }
         binding.nextButton.setOnClickListener {
             val action = R.id.action_fragment_search_to_fragment_search_results
             findNavController().navigate(action)
-        }
-    }
-
-
-    @Suppress("DEPRECATION")
-    private fun dispatchTakePictureIntent() {
-        val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        startActivityForResult(cameraIntent, REQUEST_IMAGE_CAPTURE)
-    }
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == REQUEST_IMAGE_CAPTURE && resultCode == RESULT_OK) {
-            val imageBitmap = data?.extras?.get("data") as Bitmap
-            binding.searchImageView.setImageBitmap(imageBitmap)
-            binding.nextButton.setVisibility(View.VISIBLE)
         }
     }
 }


### PR DESCRIPTION
El acceso a la camara para Search y DrPlantis estaba exactamente igual, asi que saque la logica de la camara a una clase aparte "CameraHandler" y la use en ambas pantallas

Tambien cambié algo que estaba deprecado ("startActivityForResult")