### PR TITLE
Persistencia de Plantas

### DIFF
--- a/app/src/main/java/ar/utn/frba/mobile/plantis/Plantis.kt
+++ b/app/src/main/java/ar/utn/frba/mobile/plantis/Plantis.kt
@@ -1,0 +1,3 @@
+package ar.utn.frba.mobile.plantis
+
+data class Plantis(val plants: MutableList<PlantDetail> = mutableListOf())

--- a/app/src/main/java/ar/utn/frba/mobile/plantis/PlantisStorage.kt
+++ b/app/src/main/java/ar/utn/frba/mobile/plantis/PlantisStorage.kt
@@ -1,0 +1,46 @@
+package ar.utn.frba.mobile.plantis
+
+import android.app.Activity
+import android.content.Context
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.Serializable
+import java.lang.Exception
+
+object PlantisStorage {
+    private const val mode = Context.MODE_PRIVATE
+
+    fun addPlant(activity: Activity, plant: PlantDetail) {
+        val sharedPreferences = activity.getPreferences(mode)
+        val plantListAsJson = sharedPreferences.getString("plantis", """
+            {
+                "plantis": []
+            }
+        """.trimIndent())
+        val plantList = ObjectMapper().readValue(plantListAsJson, PlantisDto::class.java)
+        plantList.plantis.add(plant)
+        val newPlantJson = ObjectMapper().writeValueAsString(plantList)
+
+        with (sharedPreferences.edit()) {
+            putString("plantis", newPlantJson)
+            apply()
+        }
+    }
+
+    fun getPlants(activity: Activity): PlantisDto {
+        try {
+            val sharedPreferences = activity.getPreferences(mode)
+            val plantListAsJson = sharedPreferences.getString("plantis", """
+            {
+                "plantis": []
+            }
+        """.trimIndent())
+            val plantList = ObjectMapper().readValue(plantListAsJson, PlantisDto::class.java)
+            return plantList
+        } catch (e: Exception) {
+            throw e
+        }
+
+    }
+}
+
+data class PlantisDto(val plantis: MutableList<PlantDetail> = mutableListOf())

--- a/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/MyGardenFragment.kt
+++ b/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/MyGardenFragment.kt
@@ -12,10 +12,7 @@ import androidx.core.os.bundleOf
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import ar.utn.frba.mobile.plantis.GardenAdapter
-import ar.utn.frba.mobile.plantis.PlantDetail
-import ar.utn.frba.mobile.plantis.R
-import ar.utn.frba.mobile.plantis.Reminder
+import ar.utn.frba.mobile.plantis.*
 import ar.utn.frba.mobile.plantis.databinding.FragmentMyGardenBinding
 import java.time.DayOfWeek
 import java.time.LocalTime
@@ -33,7 +30,7 @@ class MyGardenFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val plantList = listOf(
+        val plantList = mutableListOf(
             PlantDetail("Pothos", "Epipremnum aureum",
                 """
                     Epipremnum aureum is a species in the arum family Araceae, native to Mo'orea in the Society Islands of French Polynesia. The species is a popular houseplant in temperate regions but has also become naturalised in tropical and sub-tropical forests worldwide, including northern South Africa, Australia, Southeast Asia, South Asia, the Pacific Islands and the West Indies, where it has caused severe ecological damage in some cases.
@@ -97,6 +94,9 @@ class MyGardenFragment : Fragment() {
                 "https://upload.wikimedia.org/wikipedia/commons/4/4f/Thymus_vulgaris1.JPG",
                 "https://en.wikipedia.org/wiki/Thymus_vulgaris")
         )
+
+        val storagePlants = PlantisStorage.getPlants(requireActivity()).plantis
+        plantList.addAll(storagePlants)
 
         val viewManager = LinearLayoutManager(this.context)
         val viewAdapter = GardenAdapter(view, plantList)

--- a/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/MyGardenFragment.kt
+++ b/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/MyGardenFragment.kt
@@ -2,7 +2,6 @@ package ar.utn.frba.mobile.plantis.fragments
 
 import android.os.Build
 import android.os.Bundle
-import android.os.StrictMode
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -95,7 +94,7 @@ class MyGardenFragment : Fragment() {
                 "https://en.wikipedia.org/wiki/Thymus_vulgaris")
         )
 
-        val storagePlants = PlantisStorage.getPlants(requireActivity()).plantis
+        val storagePlants = PlantisStorage.getPlantis(requireActivity()).second.plants
         plantList.addAll(storagePlants)
 
         val viewManager = LinearLayoutManager(this.context)

--- a/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/MyPlantisFragment.kt
+++ b/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/MyPlantisFragment.kt
@@ -45,7 +45,6 @@ class MyPlantisFragment : Fragment() {
 
         Glide.with(_context).load(plantDetails.imageUrl).into(binding.plantImage)
 
-
         setUpPlantInfo(plantDetails)
 
         if (plantDetails.reminders.isEmpty())
@@ -93,5 +92,4 @@ class MyPlantisFragment : Fragment() {
         val bundle = bundleOf()
         Navigation.findNavController(view).navigate(action, bundle)
     }
-
 }

--- a/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/MyPlantisFragment.kt
+++ b/app/src/main/java/ar/utn/frba/mobile/plantis/fragments/MyPlantisFragment.kt
@@ -62,7 +62,7 @@ class MyPlantisFragment : Fragment() {
             adapter = viewAdapter
         }
 
-        binding.addButton.setOnClickListener { openAddPlantDialog(view) }
+        binding.addButton.setOnClickListener { openAddPlantDialog(view, plantDetails) }
     }
 
     private fun setUpPlantInfo(plantDetails: PlantDetail) {
@@ -72,13 +72,13 @@ class MyPlantisFragment : Fragment() {
         Glide.with(_context).load(plantDetails.imageUrl).into(binding.plantImage)
     }
 
-    private fun openAddPlantDialog(view: View) {
+    private fun openAddPlantDialog(view: View, plantDetails: PlantDetail) {
         val builder = activity.let { AlertDialog.Builder(it) }
         val alert = builder.apply {
             setTitle("Add Plant")
             setMessage("Do you want to add this plant to your Garden?")
             setPositiveButton("OK") { dialog, _ ->
-                // TODO: cuando tengamos la persistencia aca habria que guardar la planta en el storage
+                PlantisStorage.addPlant(requireActivity(), plantDetails)
                 toMyGarden(dialog, view)
             }
             setNegativeButton("CANCEL") { dialog, _ -> dialog.dismiss() }


### PR DESCRIPTION
Ahora aparte de la lista hardcodeada de plantas, podes agregar una planta y despues la vas a tener en la lista, aunque cierres la app.

De todas las alternativas que hay para persistir datos (SharedPreferences, Internal Storage, External Storage, DB SQLite) opté por SharedPreferences porque es la mas sencilla de implementar y como los usuarios no van a tener mil millones de plantas dudo que haya problemas de performance.

Basicamente se esta guardando la lista de plantas como JSON en el value de la key "plantis", y cada vez que se quiere agregar una planta se obtiene ese json, se agrega el elemento correspondiente y se sobreescribe en el value de la key "plantis"